### PR TITLE
fix: mapIterator doesn't need to wait for all promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,12 +44,17 @@ async function * mapIterator (iterator, func, n = 16) {
       .catch((err) => { _err = err })
 
     if (limit.pendingCount > 1) {
-      yield * await Promise.all(promises)
+      for (const promise of promises) {
+        yield await promise
+      }
       promises = []
     }
   }
 
-  yield * await Promise.all(promises)
+  for (const promise of promises) {
+    yield await promise
+  }
+  promises = []
 }
 
 async function map (iterator, func, n = 16) {


### PR DESCRIPTION
If the first promise has completed then we can yield
immediately without waiting for rest.