### PR TITLE
chore: use self-referencing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hwp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hwp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "@fastify/pre-commit": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "HighWatermark Processing with Async Iterators",
   "main": "index.js",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
   "scripts": {
     "lint": "eslint . --fix",
     "test": "eslint . && node --test && npm run test:types",

--- a/test/forEach.js
+++ b/test/forEach.js
@@ -3,7 +3,7 @@
 const { test, describe } = require('node:test')
 const assert = require('node:assert/strict')
 const { promisify } = require('node:util')
-const hwp = require('..')
+const hwp = require('hwp')
 
 const immediate = promisify(setImmediate)
 

--- a/test/map.js
+++ b/test/map.js
@@ -3,7 +3,7 @@
 const { test, describe } = require('node:test')
 const assert = require('node:assert/strict')
 const { promisify } = require('node:util')
-const hwp = require('..')
+const hwp = require('hwp')
 
 const immediate = promisify(setImmediate)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "commonjs",
+    "module": "node16",
     "lib": ["es2020", "dom"],
     "declaration": true,
     "strict": true,
@@ -13,7 +13,7 @@
     "noUnusedParameters": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true

--- a/typetests/index.test.ts
+++ b/typetests/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'tstyche'
-import * as hwp from '..'
+import * as hwp from 'hwp'
 
 test('mapIterator', () => {
   async function * generator () {


### PR DESCRIPTION
This PR adds the [`exports`](https://nodejs.org/docs/latest/api/packages.html#exports) fields to `package.json`. According to Node.js documentation, it is “supported in Node.js 12+”.

This change allows using self-referencing, or simply `require('hwp')` in the test files.

TypeScript supports self-referencing with `moduleResolution: "node16"`.

In a way, this means the lowest supported Node.js version becomes `v16`. (Not strictly so, because the `main` field is still there.) Since tests are currently running only agains Node.js `v20` and `v22`, seems like that should be acceptable.